### PR TITLE
Feature: Make translations of exercises and ingredients easier 

### DIFF
--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -187,7 +187,8 @@ class ExercisesEditAddView(WgerFormMixin):
                           'muscles_secondary',
                           'equipment',
                           'license',
-                          'license_author']
+                          'license_author',
+                          'language']
 
             class Media:
                 js = ('/static/bower_components/tinymce/tinymce.min.js',)
@@ -223,7 +224,7 @@ class ExerciseAddView(ExercisesEditAddView, LoginRequiredMixin, CreateView):
         '''
         Set language, author and status
         '''
-        form.instance.language = load_language()
+        form.instance.language = load_language(form.instance.language.short_name)
         form.instance.set_author(self.request)
         return super(ExerciseAddView, self).form_valid(form)
 

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -235,8 +235,7 @@ class Ingredient(AbstractLicenseModel, models.Model):
         ordering = ["name", ]
 
     language = models.ForeignKey(Language,
-                                 verbose_name=_('Language'),
-                                 editable=False)
+                                 verbose_name=_('Language'))
 
     user = models.ForeignKey(User,
                              verbose_name=_('User'),

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -143,6 +143,7 @@ class IngredientMixin(WgerFormMixin):
               'fibres',
               'sodium',
               'license',
+              'language',
               'license_author']
 
 
@@ -188,7 +189,7 @@ class IngredientCreateView(IngredientMixin, CreateView):
                              message,
                              fail_silently=True)
 
-        form.instance.language = load_language()
+        form.instance.language = load_language(form.instance.language.short_name)
         return super(IngredientCreateView, self).form_valid(form)
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Make translation of ingredients and exercises easier.

## Description of tasks to be completed

Usually, when a new exercise or ingredient is added, they are usually added in the default language the user is currently working on. I implemented a language feature to make exercises and ingredients have their own personalized language.

## What are the relevant pivotal tracker stories?
-139473445 

## Screenshot

Add new exercise.
<img width="814" alt="screen shot 2017-03-12 at 7 24 23 am" src="https://cloud.githubusercontent.com/assets/25608335/23829556/182bd5a2-06f5-11e7-97a3-babffe859862.png">

Add new ingredient:

<img width="1210" alt="screen shot 2017-03-12 at 7 24 40 am" src="https://cloud.githubusercontent.com/assets/25608335/23829557/208556ce-06f5-11e7-8ffd-0a7686341784.png">
